### PR TITLE
Assigned `newPosts` as variable.

### DIFF
--- a/src/containers/mainContainer.js
+++ b/src/containers/mainContainer.js
@@ -19,7 +19,7 @@ const mapDispatchToProps = dispatch => {
     getPosts: page => {
       dispatch(getPosts(page)).then(response => {
         if (!response.error) {
-          newPosts = posts.concat(response.payload.data);
+          let newPosts = posts.concat(response.payload.data);
           dispatch(
             getPostsSuccess(
               newPosts,


### PR DESCRIPTION
newPosts is never defined as a variable in mainContainer, and therefore throws an error when it's run on development mode with `npm run webpack`